### PR TITLE
Only considers imports with real source spans

### DIFF
--- a/henforcer.cabal
+++ b/henforcer.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.4
 
 name:           henforcer
-version:        1.0.0.1
+version:        1.0.0.2
 synopsis:       GHC plugin to enforce user specified rules on code.
 description:    Please see the README on GitHub at <https://github.com/flipstone/henforcer#readme>
 category:       Development, Compiler Plugin, static-analysis

--- a/src/CompatGHC.hs
+++ b/src/CompatGHC.hs
@@ -29,6 +29,7 @@ module CompatGHC
   , SrcSpan
   , generatedSrcSpan
   , getLoc
+  , isGoodSrcSpan
   , ideclAs
   , ideclName
   , ideclPkgQual
@@ -110,6 +111,7 @@ import GHC
   , ideclPkgQual
   , ideclQualified
   , ideclSafe
+  , isGoodSrcSpan
   , locA
   , mkModuleName
   , moduleName

--- a/src/Henforcer/CodeStructure/Import/Import.hs
+++ b/src/Henforcer/CodeStructure/Import/Import.hs
@@ -49,13 +49,11 @@ getImports :: CompatGHC.TcGblEnv -> [Import]
 getImports tcGblEnv =
   let
     name = CompatGHC.moduleName $ CompatGHC.tcg_mod tcGblEnv
-    sourcedImport =
-      CompatGHC.isGoodSrcSpan . CompatGHC.locA . CompatGHC.getLoc
    in
     Maybe.mapMaybe
       (\imp ->
          -- Remove synthetic imports, e.g. transitively imported Backpack signatures
-         if sourcedImport imp
+         if CompatGHC.isGoodSrcSpan . CompatGHC.locA $ CompatGHC.getLoc imp
            then Just (Import name imp)
            else Nothing
       )

--- a/src/Henforcer/CodeStructure/Import/Import.hs
+++ b/src/Henforcer/CodeStructure/Import/Import.hs
@@ -13,8 +13,10 @@ module Henforcer.CodeStructure.Import.Import
   , importIsOpenWithNoHidingOrAlias
   ) where
 
-import qualified CompatGHC
+import qualified Data.Maybe as Maybe
+
 import Henforcer.CodeStructure.Import.Scheme (Alias (WithoutAlias), Scheme (Scheme), buildScheme)
+import qualified CompatGHC
 
 {- | `Import` is a subset of a CompatGHC.HsModule to be a slightly more ergonomic interface.
 
@@ -47,8 +49,17 @@ getImports :: CompatGHC.TcGblEnv -> [Import]
 getImports tcGblEnv =
   let
     name = CompatGHC.moduleName $ CompatGHC.tcg_mod tcGblEnv
+    sourcedImport =
+      CompatGHC.isGoodSrcSpan . CompatGHC.locA . CompatGHC.getLoc
    in
-    fmap (Import name) $ CompatGHC.tcg_rn_imports tcGblEnv
+    Maybe.mapMaybe
+      (\imp ->
+         -- Remove synthetic imports, e.g. transitively imported Backpack signatures
+         if sourcedImport imp
+           then Just (Import name imp)
+           else Nothing
+      )
+      (CompatGHC.tcg_rn_imports tcGblEnv)
 
 {- | Determine if the import is open, with no qualification, no alias, and no hiding
 

--- a/src/Henforcer/CodeStructure/Import/Import.hs
+++ b/src/Henforcer/CodeStructure/Import/Import.hs
@@ -15,8 +15,8 @@ module Henforcer.CodeStructure.Import.Import
 
 import qualified Data.Maybe as Maybe
 
-import Henforcer.CodeStructure.Import.Scheme (Alias (WithoutAlias), Scheme (Scheme), buildScheme)
 import qualified CompatGHC
+import Henforcer.CodeStructure.Import.Scheme (Alias (WithoutAlias), Scheme (Scheme), buildScheme)
 
 {- | `Import` is a subset of a CompatGHC.HsModule to be a slightly more ergonomic interface.
 
@@ -51,11 +51,11 @@ getImports tcGblEnv =
     name = CompatGHC.moduleName $ CompatGHC.tcg_mod tcGblEnv
    in
     Maybe.mapMaybe
-      (\imp ->
-         -- Remove synthetic imports, e.g. transitively imported Backpack signatures
-         if CompatGHC.isGoodSrcSpan . CompatGHC.locA $ CompatGHC.getLoc imp
-           then Just (Import name imp)
-           else Nothing
+      ( \imp ->
+          -- Remove synthetic imports, e.g. transitively imported Backpack signatures
+          if CompatGHC.isGoodSrcSpan . CompatGHC.locA $ CompatGHC.getLoc imp
+            then Just (Import name imp)
+            else Nothing
       )
       (CompatGHC.tcg_rn_imports tcGblEnv)
 


### PR DESCRIPTION
GHC (and possibly other plugins) can inject synthetic imports for e.g. Backpack signatures that a module transitively depends on. Before this change, it was not possible to write a qualification rule for a signature in some circumstances, e.g. when a module that imports a signature directly is imported in a module that doesn't directly import the signature.

I created a minimal reproducer of the specific issue I ran into: https://github.com/jlavelle/henforcer-backpack-reproducer. It will fail on main, and succeed on the `with-fix` branch (which points at this commit).